### PR TITLE
Updated broken links for Applying Patches section

### DIFF
--- a/help/upgrade/patches/overview.md
+++ b/help/upgrade/patches/overview.md
@@ -85,8 +85,8 @@ index c8a6fef58d31..7d01c195791e 100644
 You can apply patches using any of the following methods:
 
 -  [Quality Patches Tool](https://devdocs.magento.com/quality-patches/tool.html)
--  [Command line](../patches/apply.md#command-line)
--  [Composer](../patches/apply.md#composer)
+-  [Command line](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html?lang=en#command-line)
+-  [Composer](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html?lang=en#composer)
 
 >[!NOTE]
 >

--- a/help/upgrade/patches/overview.md
+++ b/help/upgrade/patches/overview.md
@@ -86,7 +86,7 @@ You can apply patches using any of the following methods:
 
 -  [Quality Patches Tool](https://devdocs.magento.com/quality-patches/tool.html)
 -  [Command line](/help/upgrade/patches/apply.md#command-line)
--  [Composer](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html?lang=en#composer)
+-  [Composer](/help/upgrade/patches/apply.md#composer)
 
 >[!NOTE]
 >

--- a/help/upgrade/patches/overview.md
+++ b/help/upgrade/patches/overview.md
@@ -85,7 +85,7 @@ index c8a6fef58d31..7d01c195791e 100644
 You can apply patches using any of the following methods:
 
 -  [Quality Patches Tool](https://devdocs.magento.com/quality-patches/tool.html)
--  [Command line](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html?lang=en#command-line)
+-  [Command line](/help/upgrade/patches/apply.md#command-line)
 -  [Composer](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html?lang=en#composer)
 
 >[!NOTE]


### PR DESCRIPTION
Updated broken links for Applying Patches section

## Purpose of this pull request

This pull request fixes broken links for Applying Patches section.

## Affected pages

- https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/overview.html?lang=en#applying-patches

