### PR TITLE
Update page to specify which version is used

### DIFF
--- a/help/upgrade/upgrade-compatibility-tool/integrate-analysis-tool.md
+++ b/help/upgrade/upgrade-compatibility-tool/integrate-analysis-tool.md
@@ -11,7 +11,7 @@ The [!DNL Upgrade Compatibility Tool] is now integrated with the [!DNL Site-Wide
 
 See the [[!DNL Site-Wide Analysis Tool] user guide](https://docs.magento.com/user-guide/reports/site-wide-analysis-tool.html) for more information.
 
-## Run the [!DNL Upgrade Compatibility Tool] from SWAT
+## Run the [!DNL Upgrade Compatibility Tool] from [!DNL Site-Wide Analysis Tool]
 
 Navigate to the [!DNL Site-Wide Analysis Tool] dashboard for your project and locate the [!DNL Upgrade Compatibility Tool] widget.
 
@@ -25,4 +25,4 @@ After the scan is complete, the high level results are displayed in the widget.
 
 ![UCT SWAT widget - Results](../../assets/upgrade-guide/uct-swat-results.png)
 
-Click **[!UICONTROL Download Report]** to retrieve the [!DNL Upgrade Compatibility Tool] [HTML report](../upgrade-compatibility-tool/reports.md#html-report) and review the details.
+Click **[!UICONTROL Download Report]** to retrieve the [!DNL Upgrade Compatibility Tool] [HTML report](../upgrade-compatibility-tool/reports.md#html-report) and review the details. When running the [!DNL Upgrade Compatibility Tool] through the [!DNL Site-Wide Analysis Tool] the report will show results comparing your project's version with the latest released version. 


### PR DESCRIPTION
## Purpose of this pull request
The goal of this change is to specify that UCT when run through SWAT will show results comparing the project's version with the latest Adobe Commerce released version

## Affected pages
- https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/upgrade-compatibility-tool/use-upgrade-compatibility-tool/integrate-analysis-tool.html?lang=en

## Links to Magento Open Source code
N/A
