### PR TITLE
Add changes to upgrade:check documentation since 3.0.0 version

### DIFF
--- a/help/upgrade/upgrade-compatibility-tool/run.md
+++ b/help/upgrade/upgrade-compatibility-tool/run.md
@@ -53,7 +53,7 @@ Available options for the `upgrade:check` command:
 
 | **Command** | **Available options** |
 |----------------|-----------------|
-| `upgrade:check` |<ul><li>--help: Returns all available options.</li><li>--min-issue-level: You can filter issues according to the minimum issue level (default value is WARNING).</li><li>--ignore-current-version-compatibility-issues (or -i): If you do not want to include critical issues, errors and warnings from the current version in your report.</li><li>--coming-version (or -c): Target an specific Adobe Commerce version.</li></ul> |
+| `upgrade:check` |<ul><li>--help: Returns all available options.</li><li>--current-version: Current Adobe Commerce version. This parameter is required and have to be always used.</li><li>--min-issue-level: You can filter issues according to the minimum issue level (default value is WARNING).</li><li>--ignore-current-version-compatibility-issues (or -i): If you do not want to include critical issues, errors and warnings from the current version in your report.</li><li>--coming-version (or -c): Target an specific Adobe Commerce version. Latest available will be used if ommited.</li></ul> |
 
 The [!DNL Upgrade Compatibility Tool] allows you to run the `upgrade:check` command with an `--ignore-current-version-compatibility-issues` option. Use this option when you only want to get new issues that are introduced with the update from your current version to the targeted version in your [!DNL Upgrade Compatibility Tool] report:
 
@@ -212,20 +212,18 @@ bin/uct --help
 That returns a list with all available `help` options for the [!DNL Upgrade Compatibility Tool] in a command-line interface:
 
 ```terminal
-- -a, --current-version[=CURRENT-VERSION]: Current Adobe Commerce version, version of the Adobe Commerce installation will be used if omitted.
-- -c, --coming-version[=COMING-VERSION]: Target Adobe Commerce version, latest released version of Adobe Commerce will be used if omitted. Provides a list of all available Adobe Commerce versions.
-- --json-output-path[=JSON-OUTPUT-PATH]: Path of the file where the output will be exported in json format.
-- --html-output-path[=HTML-OUTPUT-PATH]: Path of the file where the output will be exported in HTML format.
-- --context=CONTEXT: Execution context. This option is for integration purposes and does not affect the execution result.
-- -h, --help: Display help for that specific command. If no command is provided, `list` command is the default result.
-- -q, --quiet: Do not output any messages while executing the command.
-- -v, --version: Display application version.
-- --ansi, --no-ansi: Enable ANSI output.
-- -n, --no-interaction: Do not ask any interactive question while executing the command.
-- -v, --vv, --vvv, --verbose: Increase verbosity of output communications. 1 for normal output, 2 for verbose output, and 3 for DEBUG output.
+- --raw             To output raw command list
+- --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
+- --short           To skip describing commands' arguments
+- -h, --help            Display help for the given command. When no command is given display help for the list command
+- -q, --quiet           Do not output any message
+- -V, --version         Display this application version
+- --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+- -n, --no-interaction  Do not ask any interactive question
+- -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 ```
 
-However, it is possible to run `--help` as an option when running a specific command. This will return specific `--help` options for that specific command.
+It is possible to run `--help` as an option when running a specific command. This will return specific `--help` options for that specific command.
 
 Example of the `upgrade:check` command with `--help` option:
 
@@ -236,9 +234,21 @@ bin/uct upgrade:check --help
 This returns specific options that can be run for the `upgrade:check` command:
 
 ```terminal
---min-issue-level.
--i, --ignore-current-version-compatibility-issues.
+- -a, --current-version[=CURRENT-VERSION]: Current Adobe Commerce version, version of the Adobe Commerce installation will be used if omitted.
+- -c, --coming-version[=COMING-VERSION]: Target Adobe Commerce version, latest released version of Adobe Commerce will be used if omitted. Provides a list of all available Adobe Commerce versions.
+- --json-output-path[=JSON-OUTPUT-PATH]: Path of the file where the output will be exported in json format.
+- --html-output-path[=HTML-OUTPUT-PATH]: Path of the file where the output will be exported in HTML format.
+- --min-issue-level[=MIN-ISSUE-LEVEL]            Minimal issue level you want to see in the report (warning, error or critical). [default: "warning"]
+- -i, --ignore-current-version-compatibility-issues  Ignore common issues for current and coming version
+- --context=CONTEXT: Execution context. This option is for integration purposes and does not affect the execution result.
+- -h, --help: Display help for that specific command. If no command is provided, `list` command is the default result.
+- -q, --quiet: Do not output any messages while executing the command.
+- -v, --version: Display application version.
+- --ansi, --no-ansi: Enable ANSI output.
+- -n, --no-interaction: Do not ask any interactive question while executing the command.
+- -v, --vv, --vvv, --verbose: Increase verbosity of output communications. 1 for normal output, 2 for verbose output, and 3 for DEBUG output.
 ```
+
 
 ## Follow Adobe Commerce Best Practices
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add changes to upgrade:check documentation since 3.0.0 version, where param --current-version become required

## Affected pages

https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/upgrade-compatibility-tool/use-upgrade-compatibility-tool/run.html

