### PR TITLE
Feature/cloud remote storage

### DIFF
--- a/help/configuration/remote-storage/cloud-support.md
+++ b/help/configuration/remote-storage/cloud-support.md
@@ -13,7 +13,7 @@ With `ece-tools` 2002.1.5 and later, you can use the `REMOTE_STORAGE` variable t
 
 The `REMOTE_STORAGE` variable takes a JSON string to configure remote storage. Below is an example JSON configuration.
 
-```
+```json
 {
   "driver": "aws-s3",
   "prefix": "uat",
@@ -28,16 +28,23 @@ The `REMOTE_STORAGE` variable takes a JSON string to configure remote storage. B
 
 To add the new environment variable for remote storage using the `magento-cloud` cli use the following command
 
-```
+```bash
 magento-cloud variable:create --level environment --name REMOTE_STORAGE --json true --inheritable false --value '{"driver":"aws-s3","prefix":"uat","config":{"bucket":"aws-bucket-id","region":"eu-west-1","key":"optional-key","secret":"optional-secret"}}'
 ```
 
 Running this command will create a new environment variable called REMOTE_STORAGE with the specified JSON configuration. Alternatively, you could use the web interface to add the variable to the appropriate environment.
 
-
 ### Optional authentication
 
 The `key` and `secret` are optional. During the creation of the variable, it is possible to set it to `sensitive` so that the value is not visible in the web interface hiding the `key` and `secret`. If you choose not to use the `key` and `secret` authentication method, you need to ensure the server is authorized to the S3 bucket by other means. In that case, the `key` and `secret` should be omitted from the JSON. 
+
+## Syncing the remote-storage
+After enabling the remote store module make sure to syncronize the current media files to the remote store location. 
+To start the syncronisation run the command below on the enviroment where you enabled the remote storage.
+
+```bash
+bin/magento remote-storage:sync 
+```
 
 ## Fastly configuration
 

--- a/help/configuration/remote-storage/cloud-support.md
+++ b/help/configuration/remote-storage/cloud-support.md
@@ -33,6 +33,7 @@ magento-cloud variable:create --level environment --name REMOTE_STORAGE --json t
 ```
 
 Running this command will create a new environment variable called REMOTE_STORAGE with the specified JSON configuration. Alternatively, you could use the web interface to add the variable to the appropriate environment.
+During the deployment you should see the following line in your deployment logs `INFO: Remote storage driver set to: "aws-s3"`.
 
 ### Optional authentication
 

--- a/help/configuration/remote-storage/cloud-support.md
+++ b/help/configuration/remote-storage/cloud-support.md
@@ -5,6 +5,42 @@ description: See guidance on how to set up remote storage for Adobe Commerce on 
 
 # Configure remote storage for Commerce on Cloud infrastructure
 
+## Enabling remote storage
+
+With `ece-tools` 2002.1.5 and later, you can use the `REMOTE_STORAGE` variable to enable the remote storage module during deployment. It is recommended to set this to an environment-level variable so that each environment has its remote storage configuration. This ensures that files are not shared between production, staging, and integration environments. Setting the variables on an environment level also gives the flexibility of only using remote storage on select environments, such as excluding the integration environment for remote storage.
+
+### Setting the `REMOTE_STORAGE` variable
+
+The `REMOTE_STORAGE` variable takes a JSON string to configure remote storage. Below is an example JSON configuration.
+
+```
+{
+  "driver": "aws-s3",
+  "prefix": "uat",
+  "config": {
+    "bucket": "aws-bucket-id",
+    "region": "aws-region-id",
+    "key": "optional-key",
+    "secret": "optional-secret"
+  }
+}
+```
+
+To add the new environment variable for remote storage using the `magento-cloud` cli use the following command
+
+```
+magento-cloud variable:create --level environment --name REMOTE_STORAGE --json true --inheritable false --value '{"driver":"aws-s3","prefix":"uat","config":{"bucket":"aws-bucket-id","region":"eu-west-1","key":"optional-key","secret":"optional-secret"}}'
+```
+
+Running this command will create a new environment variable called REMOTE_STORAGE with the specified JSON configuration. Alternatively, you could use the web interface to add the variable to the appropriate environment.
+
+
+### Optional authentication
+
+The `key` and `secret` are optional. During the creation of the variable, it is possible to set it to `sensitive` so that the value is not visible in the web interface hiding the `key` and `secret`. If you choose not to use the `key` and `secret` authentication method, you need to ensure the server is authorized to the S3 bucket by other means. In that case, the `key` and `secret` should be omitted from the JSON. 
+
+## Fastly configuration
+
 If you choose to use the remote storage solution with an Adobe Commerce on cloud infrastructure project, use the [Amazon S3](https://docs.fastly.com/en/guides/amazon-s3) guidance in the _Fastly_ documentation to ensure that Fastly Image Optimization works with AWS S3.
 
 Be prepared with your [Fastly credentials](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/cdn/setup-fastly/fastly-configuration.html#get-fastly-credentials). On Pro projects, use SSH to connect to your server and get the Fastly credentials from the `/mnt/shared/fastly_tokens.txt` file. Staging and Production environments have unique credentials. You must get the credentials for each environment.


### PR DESCRIPTION
## Purpose of this pull request
This pull request is adding missing documentation of enabling remote storage for Adobe Commerce Cloud.

## Affected pages
https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/storage/remote-storage/cloud-support.html

