### PR TITLE
Fixes ES8 composer installation instructions.

### DIFF
--- a/help/upgrade/prepare/prerequisites.md
+++ b/help/upgrade/prepare/prerequisites.md
@@ -105,7 +105,7 @@ Support for Elasticsearch 8.x was introduced in Adobe Commerce 2.4.6. The follow
 1. In the root directory of your Adobe Commerce project, update your Composer dependencies to remove the `Magento_Elasticsearch7` module and install the `Magento_Elasticsearch8` module.
 
    ```bash
-   composer update magento/module-elasticsearch-8 --update-with-all-dependencies
+   composer require magento/module-elasticsearch-8 --update-with-all-dependencies
    ```
 
 1. Update your project components.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the composer command to install the Elasticsearch 8 module

The original instruction doesn't work and is wrong:

```
$ composer update magento/module-elasticsearch-8 --update-with-all-dependencies


  The "--update-with-all-dependencies" option does not exist.
```

The correct command is to use `require` and not `update`, then it works as expected:
```
$ composer require magento/module-elasticsearch-8 --update-with-all-dependencies
Info from https://repo.packagist.org: #StandWithUkraine
./composer.json has been updated
Running composer update magento/module-elasticsearch-8 --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Lock file operations: 4 installs, 4 updates, 1 removal
  - Removing magento/module-elasticsearch-7 (100.4.6)
  - Upgrading composer/composer (2.5.4 => 2.5.5)
  - Locking elastic/transport (v8.6.0)
  - Upgrading elasticsearch/elasticsearch (v7.17.1 => v8.5.3)
  - Upgrading laminas/laminas-i18n (2.21.0 => 2.22.0)
  - Locking magento/module-elasticsearch-8 (100.4.0)
  - Locking php-http/httplug (2.3.0)
  - Locking php-http/promise (1.1.0)
  - Upgrading webonyx/graphql-php (v15.2.3 => v15.2.4)
...
```

## Affected pages

- https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/prepare/prerequisites.html#upgrade-elasticsearch

## Links to Magento Open Source code

N/A
