### PR TITLE
Explicitly state version required for multiple_processes

### DIFF
--- a/help/configuration/queues/manage-message-queues.md
+++ b/help/configuration/queues/manage-message-queues.md
@@ -68,7 +68,7 @@ Edit the `/app/etc/env.php` file to configure the cron job `consumers_runner`.
 - `cron_run` - A boolean value that enables or disables the `consumers_runner` cron job (default = `true`).
 - `max_messages` - The maximum number of messages each consumer must process before terminating (default = `10000`). Although we do not recommend it, you can use 0 to prevent the consumer from terminating. See [`consumers_wait_for_messages`](../reference/config-reference-envphp.md#consumerswaitformessages) to configure how consumers process messages from the message queue.
 - `consumers` - An array of strings specifying which consumers to run. An empty array runs *all* consumers.
-- `multiple_processes` - An array of key-value pairs specifying which consumer to run in how many processes.
+- `multiple_processes` - An array of key-value pairs specifying which consumer to run in how many processes - Supported in Commerce 2.4.4 or greater.
 
    >[!INFO]
    >


### PR DESCRIPTION
Add mention of supported version in RabbitMQ docs, to align with the deploy variables docs.

Reference: https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure/env/stage/variables-deploy.html?lang=en#cron_consumers_runner

## Purpose of this pull request

This pull request (PR) ...

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
