### PR TITLE
Remove the 'type' attribute from Tab's attributes, as it is invalid type.

### DIFF
--- a/help/configuration/reference/config-reference-systemxml.md
+++ b/help/configuration/reference/config-reference-systemxml.md
@@ -47,7 +47,6 @@ A `<tab>`-Tag can have the following attributes:
 |-------------|------------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
 | `id`        | Defines the identifier that is used referencing the section.                                                                             | `typeId` | required |
 | `translate` | Defines the field that should be translatable. Provide `label` to make the label translatable.                                           | `string` | optional |
-| `type`      | Defines the input type of the rendered HTML element—defaults to `text`.                                                                  | `string` | optional |
 | `sortOrder` | Defines the sort order of the section. High numbers push the section to the bottom of the page; low numbers push the section to the top. | `float`  | optional |
 | `class`     | Adds a defined CSS class to the rendered tab HTML element.                                                                               | `string` | optional |
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) aims to remove the 'type' attribute from Tab's attributes, as it is invalid type on the "system.xml reference" page

Fixes https://github.com/AdobeDocs/commerce-operations.en/issues/105

## Affected pages
- https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-systemxml.html#tab-attribute-reference

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
Reference:
vendor/magento/module-config/etc/system_file.xsd
```
<xs:element name="tab">
    <xs:annotation>
        <xs:documentation>
            Tab resource. Recursive complex type.
        </xs:documentation>
    </xs:annotation>

    <xs:complexType>
        <xs:sequence>
            <xs:element maxOccurs="1" name="label" type="xs:string" />
        </xs:sequence>
        <xs:attributeGroup ref="tabAttributeGroup"/>
    </xs:complexType>
</xs:element>
```
`tabAttributeGroup` is declared as the following
```
<xs:attributeGroup name="tabAttributeGroup">
    <xs:attribute name="id" type="typeId" use="required" />
    <xs:attribute name="translate" type="xs:string" use="optional" />
    <xs:attribute name="sortOrder" type="xs:float" use="optional" />
    <xs:attribute name="class" type="xs:string" use="optional" />
</xs:attributeGroup>
```
Therefore, we can confirm that the 'type' attribute is invalid attribute.