### PR TITLE
Remove incorrect or outdated information related to the 'bin/magento config:set' command

### DIFF
--- a/help/configuration/cli/set-configuration-values.md
+++ b/help/configuration/cli/set-configuration-values.md
@@ -135,8 +135,6 @@ The following table describes the `set` command parameters:
 >[!INFO]
 >
 >As of Commerce 2.2.4, the `--lock-env` and `--lock-config` options replace the `--lock` option.
->
->If you use the `--lock-env` or `--lock-config` option to set or change a value, you must use the [`bin/magento app:config:import` command](../cli/import-configuration.md) to import the setting before you access the Admin or storefront.
 
 If you enter an incorrect configuration path, this command returns an error
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes incorrect or outdated information related to the `bin/magento config:set` command:

> If you use the `--lock-env` or `--lock-config` option to set or change a value, you must use the [`bin/magento app:config:import` command](../cli/import-configuration.md) to import the setting before you access the Admin or storefront.


## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
