### PR TITLE
Use Short Array Notation in env.php Example

### DIFF
--- a/help/configuration/cache/redis-session.md
+++ b/help/configuration/cache/redis-session.md
@@ -63,11 +63,9 @@ bin/magento setup:config:set --session-save=redis --session-save-redis-host=127.
 Commerce adds lines similar to the following to `<magento_root>app/etc/env.php`:
 
 ```php
-    'session' =>
-    array (
-      'save' => 'redis',
-      'redis' =>
-      array (
+'session' => [
+    'save' => 'redis',
+    'redis' => [
         'host' => '127.0.0.1',
         'port' => '6379',
         'password' => '',
@@ -85,9 +83,9 @@ Commerce adds lines similar to the following to `<magento_root>app/etc/env.php`:
         'bot_lifetime' => '7200',
         'disable_locking' => '0',
         'min_lifetime' => '60',
-        'max_lifetime' => '2592000'
-      )
-    ),
+        'max_lifetime' => '2592000',
+    ],
+],
 ```
 
 >[!INFO]


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces the `array()` notation used in the example `env.php` snippet with the short `[]` notation to ease readability and reflect how the file will _actually_ look to users.

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cache/redis/redis-session
