### PR TITLE
Update php-extensions.md - Add redis php module

### DIFF
--- a/help/_includes/templated/php-extensions.md
+++ b/help/_includes/templated/php-extensions.md
@@ -29,6 +29,7 @@ Adobe Commerce requires:
 -  `ext-zip`
 -  `ext-zlib`
 -  `lib-libxml`
+-  `lib-redis`
 
 Magento Open Source requires:
 
@@ -58,3 +59,4 @@ Magento Open Source requires:
 -  `ext-zip`
 -  `ext-zlib`
 -  `lib-libxml`
+-  `lib-redis`


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) includes line to install Redis module for Redis session

## Affected pages

- https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements#php-extensions
- https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/php-settings#verify-installed-extensions

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- https://github.com/magento/magento2/tree/2.4-develop/lib/internal/Magento/Framework/App/Backpressure/SlidingWindow

- I installed Redis but getting session error then found PHP Redis module is mandatory.
- If not install then Redis Session is not working.
