### PR TITLE
ACP2E-3957: [Documentation] Update documentation regarding X-Magento-Cache-Id in graphQL mutation requests

### DIFF
--- a/help/release/release-notes/commerce/2-4-7.md
+++ b/help/release/release-notes/commerce/2-4-7.md
@@ -1514,6 +1514,10 @@ We have fixed hundreds of issues in the Adobe Commerce 2.4.7 core code. A subset
 
 * The declaration of the `is_subscribed` flag, its resolver, cache, and associated tests have been moved from the `CustomerGraphQl` module to the `NewsletterGraphQl` module.
 
+<!-- ACP2E-3957 -->
+
+* The X-Magento-Cache-Id header has been removed from GraphQL mutation responses. Since mutations are state-changing operations (such as adding items to the cart or placing an order), they are not meant to be cached. Including this header was misleading and could lead to incorrect behavior if caching were applied. This change aligns with GraphQL best practices and the core principles of Adobe Commerce’s architecture.
+
 <!-- AC-9362 -->
 
 * The `addProductsToCart` mutation no longer reports unrelated errors in `user_errors`. Previously, errors related to the cart were included in `user_errors` along with the expected operation errors. [GitHub-37908](https://github.com/magento/magento2/issues/37908)


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds the additional information regarding the removal of X-Magento-Cache-Id in graphQL mutation.

## Affected pages

https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/adobe-commerce/2-4-7#graphql-1