### PR TITLE
Update system-requirements-table.md | 2.4.8 versions, left to right

### DIFF
--- a/help/_includes/templated/system-requirements-table.md
+++ b/help/_includes/templated/system-requirements-table.md
@@ -109,8 +109,8 @@
   <thead>
     <tr>
       <th>Software dependencies</th>
-      <th>2.4.8</th>
       <th>2.4.8-p1</th>
+      <th>2.4.8</th>
     </tr>
   </thead>
   <tbody>
@@ -180,10 +180,10 @@
     <tr>
       <td><span class="uicontrol">[!DNL Varnish]</span></td>
       <td>
-          7.6
+          7.7
       </td>
       <td>
-          7.7
+          7.6
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
This pull request (PR)...

Now lists the 2.4.8 versions with the newest on the left, to match all other versions (2.4.7 etc.). 

Updates: 
- https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements
