### PR TITLE
Adjusting redis docs

### DIFF
--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -270,6 +270,24 @@ stage:
             compression_lib: 'gzip'       # snappy and lzf for performance, gzip for high compression (~69%)
 ```
 
+## Enable Redis asynchronous freeing (lazyfree)
+To enable `lazyfree` on Adobe Commerce on cloud infrastructure, submit an [Adobe Commerce Support ticket](https://experienceleague.adobe.com/docs/commerce-knowledge-base/kb/help-center-guide/magento-help-center-user-guide.html#submit-ticket) requesting the following Redis configuration be applied to your environment(s):
+```
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-server-del yes
+replica-lazy-flush yes
+lazyfree-lazy-user-del yes
+```
+When lazyfree is enabled, Redis offloads memory reclamation to background threads for evictions, expirations, server-initiated deletes, user deletes, and replica dataset flushes. This reduces main-thread blocking and can lower request latency.
+>[!NOTE]
+>
+>`lazyfree-lazy-user-del yes` makes the `DEL` command behave like `UNLINK`, i.e., it unlinks keys immediately and frees their memory asynchronously.
+
+>[!WARNING]
+>
+>Because freeing occurs in the background, memory used by deleted/expired/evicted keys remains allocated until background threads complete the work. If your Redis is already under tight memory pressure, test cautiously and consider reducing memory pressure first (for example, disabling Block cache for specific cases and separating cache and session Redis instances as described above).
+
 ## Additional information
 
 - [Redis Page Cache](../../../configuration/cache/redis-pg-cache.md)

--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -288,6 +288,22 @@ When lazyfree is enabled, Redis offloads memory reclamation to background thread
 >
 >Because freeing occurs in the background, memory used by deleted/expired/evicted keys remains allocated until background threads complete the work. If your Redis is already under tight memory pressure, test cautiously and consider reducing memory pressure first (for example, disabling Block cache for specific cases and separating cache and session Redis instances as described above).
 
+## Enable Redis multithreaded I/O
+To enable Redis I/O threading on Adobe Commerce on cloud infrastructure, submit an [Adobe Commerce Support ticket](https://experienceleague.adobe.com/docs/commerce-knowledge-base/kb/help-center-guide/magento-help-center-user-guide.html#submit-ticket) requesting the configuration below. This can improve throughput by offloading socket reads/writes and command parsing from the main thread, at the cost of higher CPU usage. Validate under load and monitor your hosts.
+```
+io-threads-do-reads yes
+io-threads 8 # choose a value lower than the number of CPU cores (check with nproc), then tune under load
+```
+
+>[!NOTE]
+>
+>I/O threads parallelize client I/O and parsing only. Redis command execution remains single-threaded.
+
+>[!WARNING]
+>
+>Enabling I/O threads can increase CPU usage and does not benefit every workload. Start with a conservative value and benchmark. If latency rises or CPU saturates, reduce `io-threads` or disable reads in I/O threads.
+
+
 ## Additional information
 
 - [Redis Page Cache](../../../configuration/cache/redis-pg-cache.md)

--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -216,7 +216,6 @@ Separating the Redis cache from Redis session allows you to manage the cache and
    SESSION_CONFIGURATION:
      _merge: true
      redis:
-       port: 6374 # check the port in $MAGENTO_CLOUD_RELATIONSHIPS and put it here (by default, you can delete this line!!)
        timeout: 5
        disable_locking: 1
        bot_first_lifetime: 60

--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -282,7 +282,7 @@ lazyfree-lazy-user-del yes
 When lazyfree is enabled, Redis offloads memory reclamation to background threads for evictions, expirations, server-initiated deletes, user deletes, and replica dataset flushes. This reduces main-thread blocking and can lower request latency.
 >[!NOTE]
 >
->`lazyfree-lazy-user-del yes` makes the `DEL` command behave like `UNLINK`, i.e., it unlinks keys immediately and frees their memory asynchronously.
+>The `lazyfree-lazy-user-del yes` option makes the `DEL` command behave like `UNLINK`, which unlinks keys immediately and frees their memory asynchronously.
 
 >[!WARNING]
 >
@@ -316,7 +316,7 @@ stage:
             read_timeout: 10
             connect_retries: 5
 ````
-These settings increase client tolerance to brief congestion on Redis by extending the reply wait window and retrying connection setup. This can reduce intermittent “cannot connect to localhost:6370” and read-timeout errors during short spikes.
+These settings increase client tolerance to brief congestion on Redis by extending the reply wait window and retrying connection setup. This can reduce intermittent `cannot connect to localhost:6370` and read-timeout errors during short spikes.
 >[!NOTE]
 >
 >They are not a fix for persistent overload.

--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -118,37 +118,44 @@ For on-premises installations, see [Redis preload feature](../../../configuratio
 
 ## Enable stale cache
 
-Reduce lock waiting times and enhance performance—especially when dealing with numerous Blocks and Cache keys—by using an outdated cache while generating a new cache in parallel. Enable stale cache and define cache types in the `.magento.env.yaml` configuration file:
+Reduce lock waiting times and enhance performance—especially when dealing with numerous Blocks and Cache keys—by using an outdated cache while generating a new cache in parallel. Enable stale cache and define cache types in the `config.php` configuration file (cloud only):
 
-```yaml
-stage:
-  deploy:
-    REDIS_BACKEND: '\Magento\Framework\Cache\Backend\RemoteSynchronizedCache'
-    CACHE_CONFIGURATION:
-      _merge: true
-      default:
-        backend_options:
-          use_stale_cache: false
-      stale_cache_enabled:
-        backend_options:
-          use_stale_cache: true
-      type:
-        default:
-          frontend: "default"
-        layout:
-          frontend: "stale_cache_enabled"
-        block_html:
-          frontend: "stale_cache_enabled"
-        reflection:
-          frontend: "stale_cache_enabled"
-        config_integration:
-          frontend: "stale_cache_enabled"
-        config_integration_api:
-          frontend: "stale_cache_enabled"
-        full_page:
-          frontend: "stale_cache_enabled"
-        translate:
-          frontend: "stale_cache_enabled"
+```
+'cache' => [
+        'frontend' => [
+            'stale_cache_enabled' => [
+                'backend' => '\\Magento\\Framework\\Cache\\Backend\\RemoteSynchronizedCache',
+                'backend_options' => [
+                    'remote_backend' => '\\Magento\\Framework\\Cache\\Backend\\Redis',
+                    'remote_backend_options' => [
+                        'persistent' => 0,
+                        'server' => 'localhost',
+                        'database' => '4',
+                        'port' => '6370',
+                        'password' => ''
+                    ],
+                    'local_backend' => 'Cm_Cache_Backend_File',
+                    'local_backend_options' => [
+                        'cache_dir' => '/dev/shm/'
+                    ],
+                    'use_stale_cache' => true,
+                ],
+                'frontend_options' => [
+                    'write_control' => false,
+                ],
+            ]
+        ],
+        'type' => [
+            'default' => ['frontend' => 'default'],
+            'layout' => ['frontend' => 'stale_cache_enabled'],
+            'block_html' => ['frontend' => 'stale_cache_enabled'],
+            'reflection' => ['frontend' => 'stale_cache_enabled'],
+            'config_integration' => ['frontend' => 'stale_cache_enabled'],
+            'config_integration_api' => ['frontend' => 'stale_cache_enabled'],
+            'full_page' => ['frontend' => 'stale_cache_enabled'],
+            'translate' => ['frontend' => 'stale_cache_enabled']
+        ],
+    ]
 ```
 
 >[!NOTE]

--- a/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
+++ b/help/implementation-playbook/best-practices/planning/redis-service-configuration.md
@@ -303,6 +303,23 @@ io-threads 8 # choose a value lower than the number of CPU cores (check with npr
 >
 >Enabling I/O threads can increase CPU usage and does not benefit every workload. Start with a conservative value and benchmark. If latency rises or CPU saturates, reduce `io-threads` or disable reads in I/O threads.
 
+## Increase Redis client timeouts and retries
+Raise the cache client’s tolerance to transient saturation by adjusting the backend options in `.magento.env.yaml`:
+```
+stage:
+  deploy:
+    CACHE_CONFIGURATION:
+      _merge: true
+      frontend:
+        default:
+          backend_options:
+            read_timeout: 10
+            connect_retries: 5
+````
+These settings increase client tolerance to brief congestion on Redis by extending the reply wait window and retrying connection setup. This can reduce intermittent “cannot connect to localhost:6370” and read-timeout errors during short spikes.
+>[!NOTE]
+>
+>They are not a fix for persistent overload.
 
 ## Additional information
 


### PR DESCRIPTION
## Purpose of this pull request

This PR improves the Redis guidance for Adobe Commerce on cloud infrastructure and clarifies configuration locations and intent. It documents how to enable stale cache on cloud, adds vetted server-side options (lazyfree and multithreaded I/O) with risks and operational notes, corrects the session configuration example, and adds client-side timeout/retry guidance. It also adds an explicit caveat that longer timeouts/retries are not a remedy for sustained overload.

## Affected pages

- help/implementation-playbook/best-practices/planning/redis-service-configuration.md

## Additional information
Summary of changes, rationale, and scope:
	1.	Stale cache enablement (cloud):
The instructions now point to config.php (cloud only) for enabling stale cache via RemoteSynchronizedCache and include a concrete configuration block. This aligns with how Cloud merges configuration and avoids implying .magento.env.yaml alone is sufficient for stale cache routing.
	2.	Session configuration example:
Removes a hardcoded port line from the session Redis example to prevent copy-paste errors. On Cloud, the service endpoint is injected via $MAGENTO_CLOUD_RELATIONSHIPS; specifying a port is usually unnecessary and often wrong.
	3.	Redis asynchronous freeing (lazyfree):
Adds operational guidance to request the following Redis settings via an Adobe Commerce Support ticket:
lazyfree-lazy-eviction yes, lazyfree-lazy-expire yes, lazyfree-lazy-server-del yes, replica-lazy-flush yes, lazyfree-lazy-user-del yes.
Explains the effect (offloading memory reclamation to background threads), a note that lazy-user-del makes DEL behave like UNLINK, and a warning about transient memory footprint under pressure.
	4.	Redis multithreaded I/O:
Adds instructions to request io-threads-do-reads yes and a tuned io-threads value via Support. Clarifies that only socket I/O and parsing are parallelized, not command execution, and includes a caution about CPU usage with guidance to benchmark and tune conservatively.
	5.	Client timeouts and retries:
Adds a small .magento.env.yaml snippet to increase read_timeout and connect_retries for cache clients. Clarifies this is to smooth brief congestion (e.g., many PHP workers connecting simultaneously) and explicitly states this is not a fix for persistent overload.


### Links to the affected code

- N/A (documentation-only changes).

### What's New highlights

whatsnew
Added [guidance](https://experienceleague.adobe.com/en/docs/commerce-operations/implementation-playbook/best-practices/planning/redis-service-configuration) for enabling stale cache on cloud via config.php; new sections on Redis lazyfree and multithreaded I/O (requestable via Support); clarified session Redis example; and added client timeout/retry guidance with an explicit overload caveat.
