### PR TITLE
Update cloud-requirements-table.md

### DIFF
--- a/help/_includes/templated/cloud-requirements-table.md
+++ b/help/_includes/templated/cloud-requirements-table.md
@@ -1226,7 +1226,7 @@
     <tr>
       <td><span class="uicontrol">[!DNL MariaDB]</span></td>
       <td>
-          10.11
+          10.11, 10.6
       </td>
       <td>
           10.6


### PR DESCRIPTION
## Purpose of this pull request

According to the release notes, MariaDB 10.6 is still supported for 2.4.5-p16:

> Adobe Commerce 2.4.5-p16 has been verified for compatibility with MariaDB 10.11, while continuing to fully support MariaDB 10.6

Source: https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/security-patches/2-4-5-patches#p16

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements

## Additional information

### What's New highlights

whatsnew
Updated [System requirements](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements): MariaDB 10.6 is still supported for 2.4.5-p16.