### PR TITLE
fix: typo in realpath cache size setting

### DIFF
--- a/help/implementation-playbook/best-practices/planning/realpath-cache-size.md
+++ b/help/implementation-playbook/best-practices/planning/realpath-cache-size.md
@@ -11,7 +11,7 @@ Realpath cache caches the real file system paths of filenames referenced instead
 
 To improve Commerce performance, use the following recommended settings to configure the `realpath_cache` settings in the `php.ini` file: 
 
-- Set the cache size to 10 MB (`realpath cache_size=10M`)
+- Set the cache size to 10 MB (`realpath_cache_size=10M`)
 - Set time to live (ttl) to 7200 seconds (`realpath_cache_ttl=7200`) 
 
 For configuration instructions, see [How to set PHP options](../../../installation/prerequisites/php-settings.md#how-to-set-php-options).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo in the "cache configuration best practices" page.

## Affected pages

- https://experienceleague.adobe.com/en/docs/commerce-operations/implementation-playbook/best-practices/planning/realpath-cache-size

## Additional information

### Links to the affected code

This looks already OK here: https://github.com/magento/magento-cloud/blob/1fdfeb3a3c77c7d2731553534b1cb658d7cde6f5/php.ini#L16